### PR TITLE
fix: use crypto/rand for nonce generation to prevent concurrent collisions

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	crand "crypto/rand"
 	"math/rand"
 	"net/http"
 	"net/http/httputil"
@@ -345,8 +346,11 @@ func computeHmac(headers APIRequestHeaders, signingKey string) (string, error) {
 }
 
 func generateNonce() string {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	result := make([]byte, 32)
-	r.Read(result)
+	if _, err := crand.Read(result); err != nil {
+		// Fall back to time-seeded PRNG only if crypto/rand is unavailable (very unusual).
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		r.Read(result)
+	}
 	return hex.EncodeToString(result)
 }


### PR DESCRIPTION
## Summary

- `generateNonce()` was using `rand.NewSource(time.Now().UnixNano())` — a deterministic PRNG seeded by wall clock time
- When multiple goroutines call this simultaneously at nanosecond precision, they get the **same seed → same nonce**
- The server rejects duplicate nonces (replay-attack protection), causing concurrent requests to return errors

Replaced with `crypto/rand.Read` which is cryptographically random and cannot produce collisions regardless of timing. The `math/rand` fallback is kept only for environments where `crypto/rand` is unavailable (extremely unusual).

## Root Cause

Identified via `TestDoubleBatch` in `blockchyp-cloud-stack` (VIP-990), which fires 3 concurrent `Enroll` requests from goroutines launched at the same instant. The nonce collision caused one of the three requests to receive a server error.

## Test plan
- [ ] Verify `go build .` passes
- [ ] Run existing SDK tests
- [ ] Verify `TestDoubleBatch` in `blockchyp-cloud-stack` passes after updating the dependency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)